### PR TITLE
Markdownテーブル表示の改善

### DIFF
--- a/src/presentation/styles/globals.scss
+++ b/src/presentation/styles/globals.scss
@@ -1,3 +1,45 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  /* テーブルのスタイリング */
+  table {
+    @apply w-full my-6 border-collapse;
+    border: 1px solid #e0e0e0;
+  }
+
+  thead {
+    @apply bg-gray-100;
+  }
+
+  th {
+    @apply px-4 py-3 text-left font-semibold border border-gray-300;
+    background-color: #f5f5f5;
+  }
+
+  td {
+    @apply px-4 py-3 border border-gray-300;
+  }
+
+  tbody tr:nth-child(odd) {
+    @apply bg-white;
+  }
+
+  tbody tr:nth-child(even) {
+    @apply bg-gray-50;
+  }
+
+  tbody tr:hover {
+    @apply bg-gray-100;
+    transition: background-color 0.2s ease;
+  }
+
+  /* レスポンシブ対応：小さい画面ではスクロール可能に */
+  @media (max-width: 768px) {
+    table {
+      @apply block overflow-x-auto;
+      white-space: nowrap;
+    }
+  }
+}


### PR DESCRIPTION
- globals.scssにテーブル用のスタイリングを追加
- ボーダー、パディング、背景色を設定
- 奇数行・偶数行で色を変えてストライプ表示
- ホバー時の背景色変更でユーザビリティ向上
- レスポンシブ対応（小画面では横スクロール可能）
- Tailwind CSSの@layerディレクティブを使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)